### PR TITLE
feat(detail) : 상세 카드 틀 잡기 & 애니메이션 적용 

### DIFF
--- a/src/app/detail/detail.module.scss
+++ b/src/app/detail/detail.module.scss
@@ -4,8 +4,10 @@
   align-items: center;
   height: 100%;
   overflow-y: auto;
-  padding: 3rem 1rem;
+  padding: 3rem 1rem 11rem 1rem;
   gap: 1.5rem;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 
   &__title {
     display: flex;
@@ -24,10 +26,32 @@
   }
 }
 
+.detail::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera*/
+}
+
 .detailButton {
   background-color: transparent;
 }
 
 .detailButton:hover {
   background-color: transparent;
+}
+
+.cards_scroll {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.card {
+  overflow: hidden;
+  height: 28.125rem;
+  width: 100%;
+  top: 0;
+  text-align: center;
+  margin-bottom: 30px;
+  position: sticky;
+  box-shadow: 0px -2px 10px 0px rgba(0, 0, 0, 0.4);
 }

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -4,16 +4,17 @@ import cx from 'classnames';
 import useUserStore from '@/stores/user';
 import styles from './detail.module.scss';
 import Button from '@/components/Button';
-import { useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import MBTICards from '@/components/MBTICards';
-
+import Card from '@/components/Card';
 const pottaOne = Potta_One({ weight: '400', subsets: ['latin'] });
 const poorStory = Poor_Story({ weight: '400', subsets: ['latin'] });
 
 export default function Page() {
   const { userId, mbti } = useUserStore();
   const [isOpen, setIsOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<null | HTMLDivElement>(null);
+  const refs = useRef<null[] | HTMLDivElement[]>([]);
 
   // MOCK_DATA
   const items = [
@@ -51,8 +52,24 @@ export default function Page() {
     },
   ];
 
+  const updateStyle = () => {
+    const headerHeight = 16;
+    if (refs.current && refs.current.length) {
+      refs.current.map((card, i) => {
+        const incValue = i * headerHeight;
+        card?.setAttribute('style', `top: ${incValue}px;`);
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.addEventListener('scroll', updateStyle);
+    }
+  }, []);
+
   return (
-    <div className={styles.detail}>
+    <div className={styles.detail} ref={containerRef}>
       <div className={styles.detail__title}>
         <p>
           {userId}님의
@@ -66,7 +83,67 @@ export default function Page() {
           <p className={poorStory.className}>더 자세히 살펴보기</p>
         </Button>
       ) : (
-        <MBTICards slides={items} />
+        <>
+          <MBTICards slides={items} />
+
+          <section className={styles.cards_scroll}>
+            {/* 팔로워/팔로잉 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[0] = element;
+              }}
+            >
+              <h2>card 1</h2>
+            </Card>
+            {/* 총 커밋 개수 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[1] = element;
+              }}
+            >
+              <h2>card 2</h2>
+            </Card>
+            {/* 주로 커밋한 날 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[2] = element;
+              }}
+            >
+              <h2>card 3</h2>
+            </Card>
+
+            {/* 코딩 라인 수 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[3] = element;
+              }}
+            >
+              <h2>card 4</h2>
+            </Card>
+            {/* 자주 사용하는 언어 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[4] = element;
+              }}
+            >
+              <h2>card 5</h2>
+            </Card>
+            {/* 나와 많이 소통한 커밋터 카드 */}
+            <Card
+              className={styles.card}
+              ref={(element) => {
+                refs.current[5] = element;
+              }}
+            >
+              <h2>card 6</h2>
+            </Card>
+          </section>
+        </>
       )}
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,15 +15,17 @@
   margin: 0;
 }
 
-html,
-body {
-  max-width: 100vw;
-  overflow-x: hidden;
+html {
   background-color: #0d1116;
-  width: 100vw;
   height: 100vh;
   color: var(--gray-30);
-  overflow-y: auto;
+  scrollbar-width: none;
+}
+body {
+  width: 100%;
+  max-width: 375px;
+  min-width: 320px;
+  height: 100%;
 }
 
 body {
@@ -34,6 +36,14 @@ body {
       rgb(var(--background-end-rgb))
     )
     rgb(var(--background-start-rgb));
+}
+
+@media (min-width: 375px) {
+  body {
+    width: 375px;
+    position: relative;
+    margin: auto;
+  }
 }
 
 a {

--- a/src/app/login/login.module.scss
+++ b/src/app/login/login.module.scss
@@ -1,4 +1,5 @@
 .login {
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,14 +1,20 @@
 import cx from 'classnames';
 import styles from './Card.module.scss';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ForwardedRef, forwardRef } from 'react';
 
 interface Props {
   className?: string;
 }
 
-export default function Card({
-  className,
-  children,
-}: PropsWithChildren<Props>) {
-  return <div className={cx(styles.Card, className)}>{children}</div>;
+function Card(
+  { className, children }: PropsWithChildren<Props>,
+  ref: ForwardedRef<HTMLDivElement | null>,
+) {
+  return (
+    <div className={cx(styles.Card, className)} ref={ref}>
+      {children}
+    </div>
+  );
 }
+
+export default forwardRef(Card);

--- a/src/components/MBTICards/MBTICards.module.scss
+++ b/src/components/MBTICards/MBTICards.module.scss
@@ -1,7 +1,11 @@
+.container {
+  width: 100%;
+  height: 17rem;
+}
 .embla {
   overflow-x: hidden;
   width: 100%;
-  height: 17rem;
+  height: 100%;
 }
 .embla__container {
   display: flex;

--- a/src/components/MBTICards/MBTICards.tsx
+++ b/src/components/MBTICards/MBTICards.tsx
@@ -46,7 +46,7 @@ function MBTICards({ slides }: PropType) {
   }, [emblaApi, onInit, onSelect]);
 
   return (
-    <>
+    <div className={styles.container}>
       <div className={styles.embla} ref={viewportRef}>
         <div className={styles.embla__container}>
           {slides.map((slide, idx) => {
@@ -89,7 +89,7 @@ function MBTICards({ slides }: PropType) {
           ))}
         </div>
       </div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
**1. global.css 수정**
- html, body css 설정 분리
- height 100vh로 유지하되 html으로 100vh 설정 옮김
- 현재 width 설정이 되어 있지 않아서 하위 컴포넌트들에서 width: 100% 주는 경우 화면 너비만큼 잡아버리는 문제가 있었음 => max-width, min-width px 단위로 설정 후 max-width보다 화면이 넓은 경우 width max-width로 고정 & margin: auto로 줘서 화면 중앙에 위치하도록 조정

**2.  상세카드 애니메이션 적용**

https://github.com/danmooozi/pi-don-fe/assets/60652298/09589fdf-a62f-44bb-b420-6564a32e9478

- 오트리가 https://m.place.naver.com/my/year-end/2022 요 페이지의 카드처럼 애니메이션을 줬으면 좋겠다고... 하셔서 한번 제 식대로 구현해보았어요ㅠ 한번 확인해보시고 함께 수정하면 좋을 것 같슴다...ㅎㅎ
